### PR TITLE
Script to add dummy users to the user database

### DIFF
--- a/comprl/scripts/dummy_user.py
+++ b/comprl/scripts/dummy_user.py
@@ -2,7 +2,6 @@
 
 import comprl.server.user_database as user_db
 import logging
-import uuid
 
 # run with python -m comprl.scripts.dummy_user
 

--- a/comprl/scripts/dummy_user.py
+++ b/comprl/scripts/dummy_user.py
@@ -1,0 +1,22 @@
+""" script to add dummy user to the user database"""
+
+import comprl.server.user_database as user_db
+import logging
+import uuid
+
+# run with python -m comprl.scripts.dummy_user
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+def insert_users():
+    """inserts four dummy user to the user_db"""
+    user_db.add_user(user_name="test1", user_token="token1")
+    user_db.add_user(user_name="test2", user_token="token2")
+    user_db.add_user(user_name="test3", user_token="token3")
+    user_db.add_user(user_name="test4", user_token="token4")
+
+
+if __name__ == "__main__":
+    insert_users()
+    pass


### PR DESCRIPTION
I added the script `dummy_user` in the folder `scripts`.

## Issue:

- resolves #74 

## Description:
- The method `insert_users` inserts four dummy users `test1` to `test4` with the tokens `token1` to `token4`

## TODO

- [ ] make it possible to pass the path to the database as a parameter when calling the script
- [ ] add more dummy user?