### PR TITLE
Disconnect/Timeout handling and Input Validation

### DIFF
--- a/comprl/client/networking.py
+++ b/comprl/client/networking.py
@@ -44,7 +44,8 @@ class ClientProtocol(amp.AMP):
             reason (object): The reason for the lost connection.
         """
         log.debug(f"Disconnected from the server. Reason: {reason}")
-        if reactor.running: reactor.stop()
+        if reactor.running:
+            reactor.stop()
         return super().connectionLost(reason)
 
     @Auth.responder
@@ -116,7 +117,7 @@ class ClientProtocol(amp.AMP):
         Args:
             msg (object): The error description.
         """
-        self.agent.on_error(msg=str(msg, encoding='utf-8'))
+        self.agent.on_error(msg=str(msg, encoding="utf-8"))
         return {}
 
 

--- a/comprl/client/networking.py
+++ b/comprl/client/networking.py
@@ -44,7 +44,7 @@ class ClientProtocol(amp.AMP):
             reason (object): The reason for the lost connection.
         """
         log.debug(f"Disconnected from the server. Reason: {reason}")
-        reactor.stop()
+        if reactor.running: reactor.stop()
         return super().connectionLost(reason)
 
     @Auth.responder
@@ -116,7 +116,7 @@ class ClientProtocol(amp.AMP):
         Args:
             msg (object): The error description.
         """
-        self.agent.on_error(msg=str(msg))
+        self.agent.on_error(msg=str(msg, encoding='utf-8'))
         return {}
 
 

--- a/comprl/client/networking.py
+++ b/comprl/client/networking.py
@@ -116,7 +116,7 @@ class ClientProtocol(amp.AMP):
         Args:
             msg (object): The error description.
         """
-        self.agent.on_error(msg=msg)
+        self.agent.on_error(msg=str(msg))
         return {}
 
 

--- a/comprl/server/__main__.py
+++ b/comprl/server/__main__.py
@@ -56,6 +56,7 @@ class Server(IServer):
         log.debug(f"Player {player.id} disconnected")
         self.matchmaking.remove(player.id)
         self.player_manager.remove(player)
+        self.game_manager.force_game_end(player.id)
 
     def on_update(self):
         """gets called every update cycle"""

--- a/comprl/server/__main__.py
+++ b/comprl/server/__main__.py
@@ -58,7 +58,7 @@ class Server(IServer):
         self.player_manager.remove(player)
         self.game_manager.force_game_end(player.id)
 
-    def on_timeout(self, player:IPlayer, failure, timeout):
+    def on_timeout(self, player: IPlayer, failure, timeout):
         """gets called when a player has a timeout"""
         log.debug(f"Player {player.id} had timeout after {timeout}s")
         player.disconnect(reason=f"Timeout after {timeout}s")

--- a/comprl/server/__main__.py
+++ b/comprl/server/__main__.py
@@ -58,6 +58,11 @@ class Server(IServer):
         self.player_manager.remove(player)
         self.game_manager.force_game_end(player.id)
 
+    def on_timeout(self, player:IPlayer, failure, timeout):
+        """gets called when a player has a timeout"""
+        log.debug(f"Player {player.id} had timeout after {timeout}s")
+        player.disconnect(reason=f"Timeout after {timeout}s")
+
     def on_update(self):
         """gets called every update cycle"""
         self.matchmaking.update()

--- a/comprl/server/interfaces.py
+++ b/comprl/server/interfaces.py
@@ -104,7 +104,7 @@ class IGame(abc.ABC):
         self.finish_callbacks: list[Callable[["IGame"], None]] = []
         self.scores: dict[PlayerID, float] = {p.id: 0.0 for p in players}
         self.start_time = datetime.now()
-        self.disconnected_player_id = None
+        self.disconnected_player_id: PlayerID | None = None
 
     def add_finish_callback(self, callback: Callable[["IGame"], None]) -> None:
         """
@@ -174,7 +174,12 @@ class IGame(abc.ABC):
 
             p.get_action(self.get_observation(p.id), _res)
 
-    def force_end(self, player_id):
+    def force_end(self, player_id: PlayerID):
+        """forces the end of the game
+
+        Args:
+            player_id (PlayerID): the player that caused the forced end
+        """
         self.disconnected_player_id = player_id
         self._end(reason="Player disconnected")
 

--- a/comprl/server/interfaces.py
+++ b/comprl/server/interfaces.py
@@ -160,7 +160,8 @@ class IGame(abc.ABC):
         for p in self.players.values():
 
             def _res(value, id=p.id):
-                # TODO: validate action here ?
+                if not self._validate_action(value):
+                    self.players[id].disconnect("Invalid action")
                 actions[id] = value
                 if len(actions) == len(self.players):
                     # all players have submitted their actions

--- a/comprl/server/interfaces.py
+++ b/comprl/server/interfaces.py
@@ -178,7 +178,7 @@ class IGame(abc.ABC):
         self.disconnected_player_id = player_id
         self._end(reason="Player disconnected")
 
-    def get_result(self) -> GameResult:
+    def get_result(self) -> GameResult | None:
         """
         Returns the result of the game.
 
@@ -193,10 +193,16 @@ class IGame(abc.ABC):
         if self.disconnected_player_id is not None:
             game_end_state = GameEndState.DISCONNECTED
 
+        user1_id = self.players[player_ids[0]].user_id
+        user2_id = self.players[player_ids[1]].user_id
+
+        if user1_id is None or user2_id is None:
+            return None
+
         return GameResult(
             game_id=self.id,
-            user1_id=self.players[player_ids[0]].user_id,
-            user2_id=self.players[player_ids[1]].user_id,
+            user1_id=user1_id,
+            user2_id=user2_id,
             score_user_1=self.scores[player_ids[0]],
             score_user_2=self.scores[player_ids[1]],
             start_time=self.start_time,

--- a/comprl/server/interfaces.py
+++ b/comprl/server/interfaces.py
@@ -176,10 +176,10 @@ class IGame(abc.ABC):
             p.get_action(self.get_observation(p.id), _res)
 
     def force_end(self, player_id: PlayerID):
-        """forces the end of the game
+        """forces the end of the game. Should be used when a player disconnects.
 
         Args:
-            player_id (PlayerID): the player that caused the forced end
+            player_id (PlayerID): the player that caused the forced end (disconnected)
         """
         self.disconnected_player_id = player_id
         self._end(reason="Player disconnected")

--- a/comprl/server/interfaces.py
+++ b/comprl/server/interfaces.py
@@ -310,6 +310,15 @@ class IServer:
         ...
 
     @abc.abstractmethod
+    def on_timeout(self, player: IPlayer, failure, timeout):
+        """
+        Gets called when a player has a timeout.
+        Args:
+            player (IPlayer): The player that has a timeout.
+        """
+        ...
+
+    @abc.abstractmethod
     def on_update(self):
         """
         Gets called when the server updates.

--- a/comprl/server/managers.py
+++ b/comprl/server/managers.py
@@ -59,6 +59,17 @@ class GameManager:
 
             del self.games[game.id]
 
+    def force_game_end(self, player_id: PlayerID):
+        involved_games: list[IGame] = []
+        for _, game in self.games.items():
+            for game_player_id in game.players:
+                if player_id == game_player_id:
+                    involved_games.append(game)
+                    break
+        for game in involved_games:
+            log.debug(f"Game was forced to end because of a disconnected player")
+            game.force_end(player_id=player_id)
+
     def get(self, game_id: GameID) -> IGame | None:
         """
         Retrieves the game instance with the specified ID.

--- a/comprl/server/managers.py
+++ b/comprl/server/managers.py
@@ -53,10 +53,11 @@ class GameManager:
         """
 
         if game.id in self.games:
-            GameData(ConfigProvider.get("game_data")).add(
-                self.games[game.id].get_result()
-            )
-
+            game_result = game.get_result()
+            if game_result is not None:
+                GameData(ConfigProvider.get("game_data")).add(game_result)
+            else:
+                log.error(f"Game had no valid result. Game-ID: {game.id}")
             del self.games[game.id]
 
     def force_game_end(self, player_id: PlayerID):

--- a/comprl/server/managers.py
+++ b/comprl/server/managers.py
@@ -255,7 +255,7 @@ class MatchmakingManager:
             player_id (PlayerID): The ID of the player to be matched.
         """
         log.debug(f"Player {player_id} is being matched")
-
+        
         if len(self.queue) > 0:
             players = [
                 self.player_manager.get_player_by_id(p_id)
@@ -277,7 +277,7 @@ class MatchmakingManager:
         Args:
             player_id (PlayerID): The ID of the player to be removed.
         """
-        pass
+        self.queue = [p for p in  self.queue if (p != player_id)]
 
     def update(self):
         """

--- a/comprl/server/managers.py
+++ b/comprl/server/managers.py
@@ -54,7 +54,6 @@ class GameManager:
 
         if game.id in self.games:
             game_result = game.get_result()
-            print(game_result)
             if game_result is not None:
                 GameData(ConfigProvider.get("game_data")).add(game_result)
             else:

--- a/comprl/server/managers.py
+++ b/comprl/server/managers.py
@@ -54,6 +54,7 @@ class GameManager:
 
         if game.id in self.games:
             game_result = game.get_result()
+            print(game_result)
             if game_result is not None:
                 GameData(ConfigProvider.get("game_data")).add(game_result)
             else:
@@ -61,6 +62,11 @@ class GameManager:
             del self.games[game.id]
 
     def force_game_end(self, player_id: PlayerID):
+        """Forces all games, that a player is currently playing, to end.
+
+        Args:
+            player_id (PlayerID): id of the player
+        """
         involved_games: list[IGame] = []
         for _, game in self.games.items():
             for game_player_id in game.players:
@@ -68,7 +74,7 @@ class GameManager:
                     involved_games.append(game)
                     break
         for game in involved_games:
-            log.debug(f"Game was forced to end because of a disconnected player")
+            log.debug("Game was forced to end because of a disconnected player")
             game.force_end(player_id=player_id)
 
     def get(self, game_id: GameID) -> IGame | None:

--- a/comprl/server/managers.py
+++ b/comprl/server/managers.py
@@ -254,7 +254,7 @@ class MatchmakingManager:
             player_id (PlayerID): The ID of the player to be matched.
         """
         log.debug(f"Player {player_id} is being matched")
-        
+
         if len(self.queue) > 0:
             players = [
                 self.player_manager.get_player_by_id(p_id)
@@ -276,7 +276,7 @@ class MatchmakingManager:
         Args:
             player_id (PlayerID): The ID of the player to be removed.
         """
-        self.queue = [p for p in  self.queue if (p != player_id)]
+        self.queue = [p for p in self.queue if (p != player_id)]
 
     def update(self):
         """

--- a/comprl/server/networking.py
+++ b/comprl/server/networking.py
@@ -364,11 +364,17 @@ class COMPFactory(ServerFactory):
         comp_player: COMPPlayer = COMPPlayer(protocol)
 
         # set up the callbacks needed for the server
-        protocol.add_connection_made_callback(lambda: self.server.on_connect(comp_player))
+        protocol.add_connection_made_callback(
+            lambda: self.server.on_connect(comp_player)
+        )
         protocol.add_connection_lost_callback(
             lambda: self.server.on_disconnect(comp_player)
         )
-        protocol.add_connection_timeout_callback(lambda failure, timeout: self.server.on_timeout(comp_player, failure, timeout))
+        protocol.add_connection_timeout_callback(
+            lambda failure, timeout: self.server.on_timeout(
+                comp_player, failure, timeout
+            )
+        )
 
         return protocol
 

--- a/comprl/server/networking.py
+++ b/comprl/server/networking.py
@@ -219,6 +219,12 @@ class COMPServerProtocol(amp.AMP):
         self.transport.loseConnection()
 
     def handle_remote_error(place, error):
+        """Is called when an error in Deferred occurs
+
+        Args:
+            place : where the error was caused
+            error : description of the error
+        """
         log.debug(f"Caught error in remote Callback at {place}")
 
 

--- a/examples/simple/agent.py
+++ b/examples/simple/agent.py
@@ -6,7 +6,8 @@ bob = Agent()
 
 @bob.event
 def get_step(obv: list[float]):
-    return [float(random.randint(1, 2))]
+    # return [float(random.randint(1, 2))]
+    return [float(input("enter number: ")) or float(random.randint(1, 2))]
 
 
 @bob.event

--- a/examples/simple/game.py
+++ b/examples/simple/game.py
@@ -1,4 +1,3 @@
-from comprl.server.data.interfaces import GameEndState, GameResult
 from comprl.server.interfaces import IGame, IPlayer
 from comprl.shared.types import PlayerID
 
@@ -27,7 +26,8 @@ class ExampleGame(IGame):
         return True
 
     def _validate_action(self, action) -> bool:
-        if len(action) < 1: return False
+        if len(action) < 1:
+            return False
         return int(action[0]) == action[0]
 
     def get_player_result(self, id: PlayerID) -> int:

--- a/examples/simple/game.py
+++ b/examples/simple/game.py
@@ -11,30 +11,19 @@ class ExampleGame(IGame):
         self.env: float = 0.0
 
     def update(self, actions: dict[PlayerID, list[float]]) -> bool:
-        for _, v in actions.items():
+        for player_id, v in actions.items():
             self.env += v[0]
+            self.scores[player_id] += v[0]
 
-        if self.env > 10:
-            return True
-        return False
+        return self.env > 10
 
     def get_observation(self, id: PlayerID) -> list[float]:
         return [self.env]
 
-    def get_result(self) -> GameResult:
-        # still dunno about this generally lol
-        return GameResult(
-            self.id,
-            list(self.players.values())[0].user_id or -1,
-            list(self.players.values())[1].user_id or -1,
-            0.0,
-            0.0,
-            self.start_time,
-            GameEndState.WIN,
-        )
-
     def _player_won(self, id: PlayerID) -> bool:
-        return False
+        for p, s in self.scores.items():
+            if p != id and s>=self.scores[id]: return False
+        return True
 
     def _validate_action(self, action) -> bool:
         return True

--- a/examples/simple/game.py
+++ b/examples/simple/game.py
@@ -22,7 +22,8 @@ class ExampleGame(IGame):
 
     def _player_won(self, id: PlayerID) -> bool:
         for p, s in self.scores.items():
-            if p != id and s>=self.scores[id]: return False
+            if p != id and s >= self.scores[id]:
+                return False
         return True
 
     def _validate_action(self, action) -> bool:

--- a/examples/simple/game.py
+++ b/examples/simple/game.py
@@ -27,7 +27,8 @@ class ExampleGame(IGame):
         return True
 
     def _validate_action(self, action) -> bool:
-        return True
+        if len(action) < 1: return False
+        return int(action[0]) == action[0]
 
     def get_player_result(self, id: PlayerID) -> int:
         return 0


### PR DESCRIPTION
## Issues

- resolves #50
- resolves #65 
- resolves #21

## Changes

### Disconnect handling
When a player disconnects, all games that he currently participates in, are being forced to end. This means all players are notified that the game ended, and the game loop stops. Additionally the player that disconnected is saved in the game as `self.disconnected_player_id`. 

### Game Result
Every game has now scores that are stored as floats in the dictionary `self.scores`.
With that and the saved disconnected player, the result of the game can be created for every game in the same way. This is now done in `IGame`. The games are now all correctly written into the database.

### Timeout handling
The `Server` has now a new method `on_timeout(player, failure, timeout)` which is called, when the connection of a player has a timeout. The player is then disconnected (with that e.g. games are handled).

### Input Validation
The actions that are send are now validated by using the abstract method `_validate_action(action)`. If an action is not valid, the player is disconnected.

### Errbacks in the protocoll
All errors in the protocol are now handled in the `handle_remote_error()` method. This method is currently just printing a log message and I'm not sure what else to do, or if these messages are already too much, because the errors mostly occur when a player disconnects, and then they can be ignored.