### PR TITLE
Updated remote error handling

### DIFF
--- a/comprl/client/networking.py
+++ b/comprl/client/networking.py
@@ -108,7 +108,12 @@ class ClientProtocol(amp.AMP):
             dict: A dictionary containing the action that should be executed.
                 Example: {"action": 1}
         """
-        return {"action": self.agent.get_step(obv)}
+        action = self.agent.get_step(obv)
+        if type(action) is list and all((type(x) is float) for x in action):
+            return {"action": action}
+        else:
+            raise Exception(f"Tried to send an action with wrong type. Only actions of type list[float] can be send.")
+        
 
     @Error.responder
     def on_error(self, msg):

--- a/comprl/client/networking.py
+++ b/comprl/client/networking.py
@@ -109,11 +109,12 @@ class ClientProtocol(amp.AMP):
                 Example: {"action": 1}
         """
         action = self.agent.get_step(obv)
-        if type(action) is list and all((type(x) is float) for x in action):
+        if isinstance(action, list) and all(isinstance(x, float) for x in action):
             return {"action": action}
         else:
             raise Exception(
-                f"Tried to send an action with wrong type. Only actions of type list[float] can be send."
+                "Tried to send an action with wrong type. "
+                "Only actions of type list[float] can be send."
             )
 
     @Error.responder

--- a/comprl/client/networking.py
+++ b/comprl/client/networking.py
@@ -112,8 +112,9 @@ class ClientProtocol(amp.AMP):
         if type(action) is list and all((type(x) is float) for x in action):
             return {"action": action}
         else:
-            raise Exception(f"Tried to send an action with wrong type. Only actions of type list[float] can be send.")
-        
+            raise Exception(
+                f"Tried to send an action with wrong type. Only actions of type list[float] can be send."
+            )
 
     @Error.responder
     def on_error(self, msg):

--- a/comprl/server/__main__.py
+++ b/comprl/server/__main__.py
@@ -64,6 +64,13 @@ class Server(IServer):
         log.debug(f"Player {player.id} had timeout after {timeout}s")
         player.disconnect(reason=f"Timeout after {timeout}s")
 
+    def on_remote_error(self, player: IPlayer, error: Exception):
+        """gets called when there is an error in deferred"""
+        if player.is_connected:
+            log.error(f"Connected player caused remote error \n {error.with_traceback}")
+        else:
+            log.debug("Disconnected player caused remote error")
+
     def on_update(self):
         """gets called every update cycle"""
         self.matchmaking.update()

--- a/comprl/server/__main__.py
+++ b/comprl/server/__main__.py
@@ -67,7 +67,7 @@ class Server(IServer):
     def on_remote_error(self, player: IPlayer, error: Exception):
         """gets called when there is an error in deferred"""
         if player.is_connected:
-            log.error(f"Connected player caused remote error \n {error.with_traceback}")
+            log.error(f"Connected player caused remote error \n {error}")
         else:
             log.debug("Disconnected player caused remote error")
 

--- a/comprl/server/interfaces.py
+++ b/comprl/server/interfaces.py
@@ -23,6 +23,7 @@ class IPlayer(abc.ABC):
     def __init__(self) -> None:
         self.id: PlayerID = IDGenerator.generate_player_id()
         self.user_id: Optional[int] = None
+        self.is_connected = True
 
     @abc.abstractmethod
     def authenticate(self, result_callback):
@@ -315,6 +316,16 @@ class IServer:
         Gets called when a player has a timeout.
         Args:
             player (IPlayer): The player that has a timeout.
+        """
+        ...
+
+    @abc.abstractmethod
+    def on_remote_error(self, player: IPlayer, error):
+        """
+        Gets called when an error in deferred occurs.
+        Args:
+            player (IPlayer): The player that caused the error.
+            error (Exception): Error that occurred
         """
         ...
 

--- a/comprl/server/interfaces.py
+++ b/comprl/server/interfaces.py
@@ -139,6 +139,8 @@ class IGame(abc.ABC):
             callback(self)
 
         for player in self.players.values():
+            if player.id == self.disconnected_player_id:
+                continue
             player.notify_end(
                 self._player_won(player.id), self._player_stats(player.id)
             )

--- a/comprl/server/networking.py
+++ b/comprl/server/networking.py
@@ -1,7 +1,7 @@
 """contains the networking components of the server"""
 
 import logging as log
-from typing import Callable
+from typing import Callable, Any
 
 from twisted.internet.interfaces import IAddress
 from twisted.internet.protocol import Protocol, ServerFactory
@@ -36,9 +36,10 @@ class COMPServerProtocol(amp.AMP):
 
         self.connection_made_callbacks: list[Callable[[], None]] = []
         self.connection_lost_callbacks: list[Callable[[], None]] = []
-        self.connection_timeout_callbacks: list[Callable[[any, any], None]] = []
+        self.connection_timeout_callbacks: list[Callable[[Any, Any], None]] = []
+        self.connection_error_callbacks: list[Callable[[Any], None]] = []
 
-    def add_connection_made_callback(self, callback):
+    def add_connection_made_callback(self, callback: Callable[[], None]):
         """adds callback that is executed, when the connection is made
 
         Args:
@@ -49,7 +50,7 @@ class COMPServerProtocol(amp.AMP):
         """
         self.connection_made_callbacks.append(callback)
 
-    def add_connection_lost_callback(self, callback):
+    def add_connection_lost_callback(self, callback: Callable[[], None]):
         """
         Adds a callback function to be executed when the connection is lost.
 
@@ -61,7 +62,7 @@ class COMPServerProtocol(amp.AMP):
         """
         self.connection_lost_callbacks.append(callback)
 
-    def add_connection_timeout_callback(self, callback):
+    def add_connection_timeout_callback(self, callback: Callable[[Any, Any], None]):
         """
         Adds a callback function to be executed when there is a timeout.
 
@@ -72,6 +73,18 @@ class COMPServerProtocol(amp.AMP):
             None
         """
         self.connection_timeout_callbacks.append(callback)
+
+    def add_connection_error_callback(self, callback: Callable[[Any], None]):
+        """
+        Adds a callback function to be executed when there occurs an error in deferred.
+
+        Args:
+            callback: The callback function to be added.
+
+        Returns:
+            None
+        """
+        self.connection_error_callbacks.append(callback)
 
     def connectionMade(self) -> None:
         """
@@ -116,6 +129,16 @@ class COMPServerProtocol(amp.AMP):
         for c in self.connection_timeout_callbacks:
             c(failure, timeout)
 
+    def connection_error(self, error) -> None:
+        """Is called when an error in Deferred occurs
+
+        Args:
+            place : where the error was caused
+            error : description of the error
+        """
+        for c in self.connection_error_callbacks:
+            c(error)
+
     def get_token(self, return_callback: Callable[[str], None]) -> None:
         """
         Retrieves a token from the client and calls the return_callback
@@ -141,7 +164,7 @@ class COMPServerProtocol(amp.AMP):
             self.callRemote(Auth)
             .addCallback(callback=callback)
             .addTimeout(ConfigProvider.get("timeout"), reactor, self.connectionTimeout)
-            .addErrback(self.handle_remote_error)
+            .addErrback(self.connection_error)
         )
 
     def is_ready(self, return_callback: Callable[[bool], None]) -> bool:
@@ -159,7 +182,7 @@ class COMPServerProtocol(amp.AMP):
             self.callRemote(Ready)
             .addCallback(callback=lambda res: return_callback(res["ready"]))
             .addTimeout(ConfigProvider.get("timeout"), reactor, self.connectionTimeout)
-            .addErrback(self.handle_remote_error)
+            .addErrback(self.connection_error)
         )
 
     def notify_start(self, game_id: GameID) -> None:
@@ -190,7 +213,7 @@ class COMPServerProtocol(amp.AMP):
             self.callRemote(Step, obv=obv)
             .addCallback(callback=lambda res: return_callback(res["action"]))
             .addTimeout(ConfigProvider.get("timeout"), reactor, self.connectionTimeout)
-            .addErrback(self.handle_remote_error)
+            .addErrback(self.connection_error)
         )
 
     def notify_end(self, result, stats) -> None:
@@ -207,7 +230,7 @@ class COMPServerProtocol(amp.AMP):
         return (
             self.callRemote(EndGame, result=result, stats=stats)
             .addTimeout(ConfigProvider.get("timeout"), reactor, self.connectionTimeout)
-            .addErrback(self.handle_remote_error)
+            .addErrback(self.connection_error)
         )
 
     def send_error(self, msg: str):
@@ -221,7 +244,7 @@ class COMPServerProtocol(amp.AMP):
             None
         """
         return self.callRemote(Error, msg=str.encode(msg)).addErrback(
-            self.handle_remote_error
+            self.connection_error
         )
 
     def disconnect(self):
@@ -232,15 +255,6 @@ class COMPServerProtocol(amp.AMP):
             None
         """
         self.transport.loseConnection()
-
-    def handle_remote_error(place, error):
-        """Is called when an error in Deferred occurs
-
-        Args:
-            place : where the error was caused
-            error : description of the error
-        """
-        log.debug(f"Caught error in remote Callback at {place}")
 
 
 class COMPPlayer(IPlayer):
@@ -258,6 +272,17 @@ class COMPPlayer(IPlayer):
         """
         super().__init__()
         self.connection: COMPServerProtocol = connection
+        self.is_connected: bool = False
+
+        def set_connection(c: bool):
+            self.is_connected = c
+
+        self.connection.add_connection_made_callback(
+            callback=lambda: set_connection(True)
+        )
+        self.connection.add_connection_lost_callback(
+            callback=lambda: set_connection(False)
+        )
 
     def authenticate(self, result_callback):
         """Authenticates the player.
@@ -269,7 +294,8 @@ class COMPPlayer(IPlayer):
         Returns:
             token (string): The authentication token.
         """
-        self.connection.get_token(result_callback)
+        if self.is_connected:
+            self.connection.get_token(result_callback)
 
     def is_ready(self, result_callback) -> bool:
         """Checks if the player is ready to play.
@@ -288,7 +314,8 @@ class COMPPlayer(IPlayer):
         Args:
             game_id (GameID): The ID of the game.
         """
-        self.connection.notify_start(game_id=game_id)
+        if self.is_connected:
+            self.connection.notify_start(game_id=game_id)
 
     def get_action(self, obv, result_callback):
         """Receives the action from the server.
@@ -297,7 +324,8 @@ class COMPPlayer(IPlayer):
             obv (any): The observation.
             result_callback (callback function): The callback to handle the result.
         """
-        self.connection.get_step(obv, result_callback)
+        if self.is_connected:
+            self.connection.get_step(obv, result_callback)
 
     def notify_end(self, result, stats):
         """Called when the game ends.
@@ -306,7 +334,8 @@ class COMPPlayer(IPlayer):
             result (any): The result of the game.
             stats (any): The stats of the game.
         """
-        self.connection.notify_end(result=result, stats=stats)
+        if self.is_connected:
+            self.connection.notify_end(result=result, stats=stats)
 
     def disconnect(self, reason: str):
         """Disconnects the player.
@@ -323,7 +352,8 @@ class COMPPlayer(IPlayer):
         Args:
             error (str): The error message.
         """
-        self.connection.send_error(error)
+        if self.is_connected:
+            self.connection.send_error(error)
 
 
 class COMPFactory(ServerFactory):
@@ -374,6 +404,9 @@ class COMPFactory(ServerFactory):
             lambda failure, timeout: self.server.on_timeout(
                 comp_player, failure, timeout
             )
+        )
+        protocol.add_connection_error_callback(
+            lambda error: self.server.on_remote_error(comp_player, error)
         )
 
         return protocol

--- a/comprl/server/networking.py
+++ b/comprl/server/networking.py
@@ -258,7 +258,7 @@ class COMPServerProtocol(amp.AMP):
             None
         """
         return self.callRemote(Message, msg=str.encode(msg)).addErrback(
-            self.handle_remote_error
+            self.connection_error
         )
 
     def disconnect(self):


### PR DESCRIPTION
# Problem

@PacoSchatz and I noticed that the remote error handling that was introduced with a dummy handling function in #82 is not practical for debugging. The problem was that a disconnected player can cause remote errors, but they are not really that important because the player already disconnected, and everything is handled. But for connected players, the remote errors are important for debugging.
 
# Changes

This problem is trying to be solved here, by making sure that there are less remote errors and sorting the errors by connected and disconnected players.

## Action validation on client side

It is now checked that every action that is being sent is a list of floats. This makes sure that the client does not send something that would cause a remote error. But the actual action validation still happens on the server side. 

## Knowing which player is connected

Every player has now a variable `is_connected`. I'm not sure if that is the best solution. It would also be possible to do this with the connected player list in the player manager, but I thought this would be more complicated. But I am open for other suggestions here.

## Sending commands

Commands (e.g. to notify start, end, ...) are now only sent if the player is actually connected. This also reduces the number or remote errors.

## Handling remote errors

The remote errors are now handled by the `Server` by the method `on_remote_error()`. There are different error messages created for connected and disconnected players.