### PR TITLE
Update: UserData supports passwords and roles now

### DIFF
--- a/comprl/scripts/dummy_user.py
+++ b/comprl/scripts/dummy_user.py
@@ -18,10 +18,10 @@ logging.basicConfig(level=logging.DEBUG)
 
 def insert_users():
     """inserts four dummy user to the user database"""
-    user_data.add(user_name="test1", user_token="token1")
-    user_data.add(user_name="test2", user_token="token2")
-    user_data.add(user_name="test3", user_token="token3")
-    user_data.add(user_name="test4", user_token="token4")
+    user_data.add(user_name="test1", user_password="password1", user_token="token1")
+    user_data.add(user_name="test2", user_password="password2", user_token="token2")
+    user_data.add(user_name="test3", user_password="password3", user_token="token3")
+    user_data.add(user_name="test4", user_password="password4", user_token="token4")
 
     logging.info("Four dummy users have been added.")
 

--- a/comprl/scripts/new_user.py
+++ b/comprl/scripts/new_user.py
@@ -27,8 +27,8 @@ def insert_user(name: str):
     """
     token = str(uuid.uuid4())
     password = getpass.getpass("Please enter a password for the user: ")
-    role = input("Do you want the new user to be an admin? (Y/N): ")
-    if role.lower() == "y":
+    isAdmin = input("Do you want the new user to be an admin? (Y/N): ")
+    if isAdmin.lower() == "y":
         role = UserRole.ADMIN
     else:
         role = UserRole.USER

--- a/comprl/scripts/new_user.py
+++ b/comprl/scripts/new_user.py
@@ -2,9 +2,11 @@
 
 from comprl.server.data import UserData
 from comprl.server.data import ConnectionInfo
+from comprl.server.data.interfaces import UserRole
 import logging
 import argparse
 import uuid
+import getpass
 
 try:
     import tomllib  # type: ignore[import-not-found]
@@ -24,7 +26,15 @@ def insert_user(name: str):
         name (str): name of the new user
     """
     token = str(uuid.uuid4())
-    user_data.add(user_name=name, user_password=str(uuid.uuid4()), user_token=token)
+    password = getpass.getpass("Please enter a password for the user: ")
+    role = input("Do you want the new user to be an admin? (Y/N): ")
+    if role.lower() == "y":
+        role = UserRole.ADMIN
+    else:
+        role = UserRole.USER
+    user_data.add(
+        user_name=name, user_password=password, user_token=token, user_role=role
+    )
 
 
 if __name__ == "__main__":

--- a/comprl/scripts/new_user.py
+++ b/comprl/scripts/new_user.py
@@ -24,7 +24,7 @@ def insert_user(name: str):
         name (str): name of the new user
     """
     token = str(uuid.uuid4())
-    user_data.add(user_name=name, user_token=token)
+    user_data.add(user_name=name, user_password=str(uuid.uuid4()), user_token=token)
 
 
 if __name__ == "__main__":

--- a/comprl/server/data/interfaces.py
+++ b/comprl/server/data/interfaces.py
@@ -73,3 +73,16 @@ class GameResult:
         self.disconnected_id = None
         if end_state == GameEndState.DISCONNECTED:
             self.disconnected_id = user1_id if is_user1_disconnected else user2_id
+
+
+class UserRole(IntEnum):
+    """
+    Represents the possible user roles.
+
+    Attributes:
+        USER: Normal user without administrative rights.
+        ADMIN = User with administrative rights.
+    """
+
+    USER = 0
+    ADMIN = 1

--- a/comprl/server/data/interfaces.py
+++ b/comprl/server/data/interfaces.py
@@ -3,7 +3,7 @@ This module contains the interfaces for the game data.
 """
 
 from datetime import datetime
-from enum import IntEnum
+from enum import IntEnum, StrEnum
 
 from comprl.shared.types import GameID
 
@@ -75,7 +75,7 @@ class GameResult:
             self.disconnected_id = user1_id if is_user1_disconnected else user2_id
 
 
-class UserRole(IntEnum):
+class UserRole(StrEnum):
     """
     Represents the possible user roles.
 
@@ -84,5 +84,5 @@ class UserRole(IntEnum):
         ADMIN = User with administrative rights.
     """
 
-    USER = 0
-    ADMIN = 1
+    USER = "user"
+    ADMIN = "admin"

--- a/comprl/server/data/interfaces.py
+++ b/comprl/server/data/interfaces.py
@@ -3,7 +3,7 @@ This module contains the interfaces for the game data.
 """
 
 from datetime import datetime
-from enum import IntEnum, StrEnum
+from enum import IntEnum, Enum
 
 from comprl.shared.types import GameID
 
@@ -75,7 +75,7 @@ class GameResult:
             self.disconnected_id = user1_id if is_user1_disconnected else user2_id
 
 
-class UserRole(StrEnum):
+class UserRole(Enum):
     """
     Represents the possible user roles.
 

--- a/comprl/server/data/sql_backend.py
+++ b/comprl/server/data/sql_backend.py
@@ -122,7 +122,7 @@ class UserData:
             user_id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
             username TEXT NOT NULL UNIQUE,
             password TEXT NOT NULL,
-            role UserRole,
+            role TEXT NOT NULL DEFAULT 'user',
             token TEXT NOT NULL,
             mu FLOAT NOT NULL,
             sigma FLOAT NOT NULL

--- a/comprl/server/data/sql_backend.py
+++ b/comprl/server/data/sql_backend.py
@@ -145,15 +145,20 @@ class UserData:
             user_name (str): The name of the user.
             user_password (str): The password of the user.
             user_token (str): The token of the user.
-            user_role (UserRole, optional): The role of the user. Defaults to UserRole.USER.
+            user_role (UserRole, optional): The role of the user.
+            Defaults to UserRole.USER.
             user_mu (float, optional): The mu value of the user. Defaults to 25.
             user_sigma (float, optional): The sigma value of the user. Defaults to 8.33.
 
         Returns:
             int: The ID of the newly added user.
         """
+
+        user_role = user_role.value
+
         self.cursor.execute(
-            f"""INSERT INTO {self.table}(username, password, role, token, mu, sigma) VALUES (?,?,?,?,?,?)""",
+            f"""INSERT INTO {self.table}(username, password, role, token, mu, sigma)
+            VALUES (?,?,?,?,?,?)""",
             (user_name, user_password, user_role, user_token, user_mu, user_sigma),
         )
         self.cursor.execute(

--- a/comprl/server/data/sql_backend.py
+++ b/comprl/server/data/sql_backend.py
@@ -5,7 +5,7 @@ Implementation of the data access objects for managing game and user data in SQL
 import dataclasses
 import sqlite3
 
-from comprl.server.data.interfaces import GameResult
+from comprl.server.data.interfaces import GameResult, UserRole
 from comprl.shared.types import GameID
 
 
@@ -120,7 +120,9 @@ class UserData:
             f"""
             CREATE TABLE IF NOT EXISTS {connection.table} (
             user_id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-            name TEXT NOT NULL,
+            username TEXT NOT NULL UNIQUE,
+            password TEXT NOT NULL,
+            role UserRole,
             token TEXT NOT NULL,
             mu FLOAT NOT NULL,
             sigma FLOAT NOT NULL
@@ -128,14 +130,22 @@ class UserData:
         )
 
     def add(
-        self, user_name: str, user_token: str, user_mu=25.000, user_sigma=8.333
+        self,
+        user_name: str,
+        user_password: str,
+        user_token: str,
+        user_role=UserRole.USER,
+        user_mu=25.000,
+        user_sigma=8.333,
     ) -> int:
         """
         Adds a new user to the database.
 
         Args:
             user_name (str): The name of the user.
+            user_password (str): The password of the user.
             user_token (str): The token of the user.
+            user_role (UserRole, optional): The role of the user. Defaults to UserRole.USER.
             user_mu (float, optional): The mu value of the user. Defaults to 25.
             user_sigma (float, optional): The sigma value of the user. Defaults to 8.33.
 
@@ -143,8 +153,8 @@ class UserData:
             int: The ID of the newly added user.
         """
         self.cursor.execute(
-            f"""INSERT INTO {self.table}(name, token, mu, sigma) VALUES (?,?,?,?)""",
-            (user_name, user_token, user_mu, user_sigma),
+            f"""INSERT INTO {self.table}(username, password, role, token, mu, sigma) VALUES (?,?,?,?,?,?)""",
+            (user_name, user_password, user_role, user_token, user_mu, user_sigma),
         )
         self.cursor.execute(
             f"""SELECT user_id FROM {self.table} WHERE token=?""",

--- a/tests/reset_database_test.py
+++ b/tests/reset_database_test.py
@@ -12,10 +12,26 @@ logging.basicConfig(level=logging.DEBUG)
 
 def reset_tests():
     user_data = UserData(ConfigProvider.get("user_data"))
-    userID1 = user_data.add(user_name="user_1", user_token=str(uuid.uuid4()))
-    userID2 = user_data.add(user_name="user_2", user_token=str(uuid.uuid4()))
-    userID3 = user_data.add(user_name="user_3", user_token=str(uuid.uuid4()))
-    userID4 = user_data.add(user_name="user_4", user_token=str(uuid.uuid4()))
+    userID1 = user_data.add(
+        user_name="user_1",
+        user_password=str(uuid.uuid4()),
+        user_token=str(uuid.uuid4()),
+    )
+    userID2 = user_data.add(
+        user_name="user_2",
+        user_password=str(uuid.uuid4()),
+        user_token=str(uuid.uuid4()),
+    )
+    userID3 = user_data.add(
+        user_name="user_3",
+        user_password=str(uuid.uuid4()),
+        user_token=str(uuid.uuid4()),
+    )
+    userID4 = user_data.add(
+        user_name="user_4",
+        user_password=str(uuid.uuid4()),
+        user_token=str(uuid.uuid4()),
+    )
 
     user_data.set_matchmaking_parameters(user_id=userID1, mu=24.000, sigma=9.333)
     user_data.set_matchmaking_parameters(user_id=userID2, mu=23.000, sigma=9.000)


### PR DESCRIPTION
I updated `UserData` so that `UserData` and `sqlite.data.tsx` from _comprl-web_ can work with the same database now.


## Issue:

- resolves #91 

## Description:
- I added the `UserRole` class to the interfaces. This is a _StrEnum_ that describes the role of a user.  A user can either be a normal `"user"` or an `"admin"` with administrative rights.
- I changed `UserData` so that it matches the user database in _comprl-web_. Therefore I changed `init` and `add`.
- I have updated all calls of the `add` method so that everything still works. This affected the `dummy_user` and `new_user` scripts and the test file `reset_database_test`.

## UserData:

- `username` is now unique
- I added a new column `password` which has the type string
- I added a new column `role` which has the type string and the default `"user"`.
- In the `add` method, `user_role` is of type _UserRole_ so that you can only choose between `"user"` and `"admin"`.