### PR TITLE
protocol generic message

### DIFF
--- a/comprl/client/agent.py
+++ b/comprl/client/agent.py
@@ -53,6 +53,10 @@ class Agent(IAgent):
         super().run(token)
         networking.connect_agent(self, host, port)
 
-    def on_error(self, msg):
+    def on_error(self, msg: str):
         """Called if an error occurred on the server side."""
         print(f"Error: {msg}")
+
+    def on_message(self, msg: str):
+        """Called if a message is sent from the server."""
+        print(f"Info: {msg}")

--- a/comprl/client/agent.py
+++ b/comprl/client/agent.py
@@ -60,3 +60,7 @@ class Agent(IAgent):
     def on_message(self, msg: str):
         """Called if a message is sent from the server."""
         print(f"Info: {msg}")
+
+    def on_disconnect(self):
+        """Called when the agent disconnects from the server."""
+        print("Error: Agent disconnected from the server.")

--- a/comprl/client/interfaces.py
+++ b/comprl/client/interfaces.py
@@ -86,3 +86,7 @@ class IAgent:
             msg (str): The message
         """
         pass
+
+    def on_disconnect(self):
+        """Called when the agent disconnects from the server."""
+        pass

--- a/comprl/client/interfaces.py
+++ b/comprl/client/interfaces.py
@@ -57,7 +57,7 @@ class IAgent:
         """
         raise NotImplementedError("step function not implemented")
 
-    def on_end_game(self, result, stats) -> None:
+    def on_end_game(self, result: bool, stats: list[float]) -> None:
         """
         Called when a game ends.
 
@@ -70,11 +70,19 @@ class IAgent:
         """
         pass
 
-    def on_error(self, msg):
+    def on_error(self, msg: str):
         """
         Called when an error occurs.
 
         Args:
-            msg: The error message.
+            msg (str): The error message.
+        """
+        pass
+
+    def on_message(self, msg: str):
+        """Called when a message is sent from the server.
+
+        Args:
+            msg (str): The message
         """
         pass

--- a/comprl/client/networking.py
+++ b/comprl/client/networking.py
@@ -8,7 +8,7 @@ from twisted.protocols import amp
 from twisted.internet import reactor
 from twisted.internet.endpoints import TCP4ClientEndpoint, connectProtocol
 
-from comprl.shared.commands import Ready, StartGame, EndGame, Step, Auth, Error
+from comprl.shared.commands import Ready, StartGame, EndGame, Step, Auth, Error, Message
 
 from .interfaces import IAgent
 
@@ -118,6 +118,16 @@ class ClientProtocol(amp.AMP):
             msg (object): The error description.
         """
         self.agent.on_error(msg=str(msg, encoding="utf-8"))
+        return {}
+    
+    @Message.responder
+    def on_message(self, msg):
+        """Called if a message from the server is sent.
+
+        Args:
+            msg (object): The message.
+        """
+        self.agent.on_message(msg=str(msg, encoding="utf-8"))
         return {}
 
 

--- a/comprl/client/networking.py
+++ b/comprl/client/networking.py
@@ -119,7 +119,7 @@ class ClientProtocol(amp.AMP):
         """
         self.agent.on_error(msg=str(msg, encoding="utf-8"))
         return {}
-    
+
     @Message.responder
     def on_message(self, msg):
         """Called if a message from the server is sent.

--- a/comprl/client/networking.py
+++ b/comprl/client/networking.py
@@ -46,6 +46,7 @@ class ClientProtocol(amp.AMP):
         log.debug(f"Disconnected from the server. Reason: {reason}")
         if reactor.running:
             reactor.stop()
+        self.agent.on_disconnect()
         return super().connectionLost(reason)
 
     @Auth.responder

--- a/comprl/server/__main__.py
+++ b/comprl/server/__main__.py
@@ -47,6 +47,7 @@ class Server(IServer):
         def __auth(token):
             if self.player_manager.auth(player.id, token):
                 self.matchmaking.try_match(player.id)
+                player.notify_info(msg="Authentication successful")
             else:
                 player.disconnect("Authentication failed")
 

--- a/comprl/server/interfaces.py
+++ b/comprl/server/interfaces.py
@@ -75,6 +75,11 @@ class IPlayer(abc.ABC):
         """notifies the player of an error"""
         ...
 
+    @abc.abstractmethod
+    def notify_info(self, msg: str):
+        """notifies the player of an information"""
+        ...
+
 
 class IGame(abc.ABC):
     """

--- a/comprl/server/managers.py
+++ b/comprl/server/managers.py
@@ -244,7 +244,13 @@ class MatchmakingManager:
 
         if player is not None:
             # FIXME: we might wan't to kick the player
-            player.is_ready(lambda res: self.match(player_id) if res else None)
+
+            def __match(ready: bool):
+                if ready:
+                    player.notify_info(msg="Waiting in queue")
+                    self.match(player_id)
+
+            player.is_ready(result_callback=__match)
 
     def match(self, player_id: PlayerID) -> None:
         """

--- a/comprl/server/networking.py
+++ b/comprl/server/networking.py
@@ -11,7 +11,7 @@ from twisted.internet.task import LoopingCall
 
 from comprl.server.interfaces import IPlayer, IServer
 from comprl.server.util import ConfigProvider
-from comprl.shared.commands import Auth, EndGame, Error, Ready, StartGame, Step
+from comprl.shared.commands import Auth, EndGame, Error, Ready, StartGame, Step, Message
 from comprl.shared.types import GameID
 
 VERSION: int = 1
@@ -221,6 +221,20 @@ class COMPServerProtocol(amp.AMP):
             None
         """
         return self.callRemote(Error, msg=str.encode(msg)).addErrback(
+            self.handle_remote_error
+        )
+    
+    def send_message(self, msg: str):
+        """
+        Send a message string to the client.
+
+        Args:
+            msg (str): The message to send.
+
+        Returns:
+            None
+        """
+        return self.callRemote(Message, msg=str.encode(msg)).addErrback(
             self.handle_remote_error
         )
 

--- a/comprl/server/networking.py
+++ b/comprl/server/networking.py
@@ -223,7 +223,7 @@ class COMPServerProtocol(amp.AMP):
         return self.callRemote(Error, msg=str.encode(msg)).addErrback(
             self.handle_remote_error
         )
-    
+
     def send_message(self, msg: str):
         """
         Send a message string to the client.
@@ -338,6 +338,14 @@ class COMPPlayer(IPlayer):
             error (str): The error message.
         """
         self.connection.send_error(error)
+
+    def notify_info(self, msg: str):
+        """Notifies the player of an information.
+
+        Args:
+            msg (str): The information message.
+        """
+        self.connection.send_message(msg)
 
 
 class COMPFactory(ServerFactory):

--- a/comprl/shared/commands.py
+++ b/comprl/shared/commands.py
@@ -57,6 +57,7 @@ class Error(Command):
     arguments = [(b"msg", String())]
     response = []
 
+
 class Message(Command):
     """Command interface for a generic message"""
 

--- a/comprl/shared/commands.py
+++ b/comprl/shared/commands.py
@@ -56,3 +56,9 @@ class Error(Command):
 
     arguments = [(b"msg", String())]
     response = []
+
+class Message(Command):
+    """Command interface for a generic message"""
+
+    arguments = [(b"msg", String())]
+    response = []


### PR DESCRIPTION
## Issues

- resolves #99 

## Changes

- Added command `Message` to the protocol
- Server side: Every player has a method `notify_info` which can be used to send generic messages.
This is currently used for successful authentication and being added to the queue, but can be used for more things in the future.
- Client side: The `Agent` prints the information by default in the method `on_message`.

- Added the method `on_disconnect` to the `Agent` and `IAgent`, that gets called when the client disconnects from the server. It currently prints a disconnect message by default.