### PR TITLE
chore: Run tests with multiple Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,18 @@ on:
 
 jobs:
   pytest:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version: ["3.10", "3.12", "3.13"]
+        os: ["ubuntu-latest"]
+    runs-on: ${{ matrix.os }}
+
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python_version }}
       - name: Install package with test dependencies
         run: |
           python -m pip install ".[test]"


### PR DESCRIPTION
Ideally it should run on all supported Python versions but to same a bit of compute time, I'm skipping the odd numbers (Ubuntu LTS versions typically come with the even ones).  Exception is 3.13 as it is the most recent one.