### PR TITLE
Bump twisted version to 24.11.0

### DIFF
--- a/comprl/pyproject.toml
+++ b/comprl/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 
 requires-python = ">=3.10"
 dependencies = [
-    "twisted==23.10.0",
+    "twisted==24.11.0",
     "numpy",
     "tomli; python_version<'3.11'",
     "hockey @ git+https://git@github.com/martius-lab/laser-hockey-env.git@cc48daa135e2cca3e620b90431e57870f61d043c",


### PR DESCRIPTION
There was an alert by GitHub's Dependabot about the version used before (two moderate CVEs).

I did a quick test, seems that everything still works normally with the new version.