### PR TITLE
Make output directory for saving game actions configurable

### DIFF
--- a/comprl/CHANGELOG.md
+++ b/comprl/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BREAKING: Removed option to configure database table names.
 - BREAKING: Database is not automatically created anymore.  Use
   `comprl.scripts.create_database`.
+- BREAKING: New config option `data_dir` to specify output directory for game actions.
+  This is a required setting (no default value), hence a breaking change.
+
+## Added
+- Script `list_games` to list all games from the database on the terminal.
 
 
 ## [0.1.0]

--- a/comprl/comprl/server/__main__.py
+++ b/comprl/comprl/server/__main__.py
@@ -6,6 +6,7 @@ import os
 import argparse
 import logging as log
 import inspect
+import pathlib
 
 try:
     import tomllib  # type: ignore[import-not-found]
@@ -123,6 +124,7 @@ def main():
     parser.add_argument("--game_class", type=str, help="Class name of the game")
     parser.add_argument("--log", type=str, help="Log level")
     parser.add_argument("--database_path", type=str, help="Path to the database file.")
+    parser.add_argument("--data_dir", type=str, help="Path to the data directory.")
     parser.add_argument(
         "--match_quality_threshold",
         type=float,
@@ -156,6 +158,7 @@ def main():
     else:
         parser.error("Need to provide either --config or --database-path")
 
+    # TODO better config management
     port = args.port or (data["port"] if data else 65335)
     timeout = args.timeout or (data["timeout"] if data else 10)
     game_path = args.game_path or (data["game_path"] if data else "game.py")
@@ -170,6 +173,7 @@ def main():
     percental_time_bonus = args.percental_time_bonus or (
         data["percental_time_bonus"] if data else 0.1
     )
+    data_dir = pathlib.Path(args.data_dir or data["data_dir"])
 
     # set up logging
     log.basicConfig(level=log_level)
@@ -188,12 +192,17 @@ def main():
         log.error("Provided game class is not valid because it is still abstract.")
         return
 
+    if not data_dir.is_dir():
+        log.error("data_dir '%s' not found or not a directory", data_dir)
+        return
+
     # write the config to the ConfigProvider
     ConfigProvider.set("port", port)
     ConfigProvider.set("timeout", timeout)
     ConfigProvider.set("log_level", log_level)
     ConfigProvider.set("game_type", game_type)
     ConfigProvider.set("database_path", database_path)
+    ConfigProvider.set("data_dir", data_dir)
     ConfigProvider.set("match_quality_threshold", match_quality_threshold)
     ConfigProvider.set("percentage_min_players_waiting", percentage_min_players_waiting)
     ConfigProvider.set("percental_time_bonus", percental_time_bonus)

--- a/comprl/comprl/server/interfaces.py
+++ b/comprl/comprl/server/interfaces.py
@@ -7,10 +7,13 @@ from typing import Callable, Optional
 from datetime import datetime
 import numpy as np
 import pickle
+import pathlib
+import logging
 
 from comprl.shared.types import GameID, PlayerID
 from comprl.server.util import IDGenerator
 from comprl.server.data.interfaces import GameResult, GameEndState
+from comprl.server.util import ConfigProvider
 
 
 class IAction:
@@ -153,7 +156,15 @@ class IGame(abc.ABC):
         # as storing the actions can take a while
         self.game_info["actions"] = np.array(self.all_actions)
 
-        with open("comprl/server/game_actions/" + str(self.id) + ".pkl", "wb") as f:
+        data_dir = pathlib.Path(ConfigProvider.get("data_dir"))
+        # should already be checked during config loading but just to be sure
+        assert data_dir.is_dir(), f"data_dir '{data_dir}' is not a directory"
+        game_actions_dir = data_dir / "game_actions"
+        game_actions_dir.mkdir(exist_ok=True)
+        output_file = game_actions_dir / f"{self.id}.pkl"
+
+        logging.debug("Save game actions to %s", output_file)
+        with open(output_file, "wb") as f:
             pickle.dump(self.game_info, f)
 
         # notify end

--- a/comprl/comprl/server/managers.py
+++ b/comprl/comprl/server/managers.py
@@ -3,12 +3,10 @@ This module contains classes that manage game instances and players.
 """
 
 import logging as log
-import pickle
 from typing import Type
 from datetime import datetime
 from openskill.models import PlackettLuce
 from typing import TypeAlias
-import numpy as np
 
 from comprl.server.interfaces import IGame, IPlayer
 from comprl.shared.types import GameID, PlayerID
@@ -92,18 +90,6 @@ class GameManager:
             Optional[IGame]: The game instance if found, None otherwise.
         """
         return self.games.get(game_id, None)
-
-    def get_stored_actions(self, game_id: GameID) -> dict[str, list[np.ndarray]]:
-        """get a game from the log file
-
-        Args:
-            game_id (GameID): id of the game we want to get
-        Returns:
-            dict[str, list[np.ndarray]]: the dict containing the actions and possible
-            more info
-        """
-        with open("comprl/server/game_actions/" + str(game_id) + ".pkl", "rb") as f:
-            return pickle.load(f)
 
 
 class PlayerManager:

--- a/comprl/examples/hockey/config.toml
+++ b/comprl/examples/hockey/config.toml
@@ -5,6 +5,7 @@
     game_path = "examples/hockey/hockey_game.py"
     game_class = "HockeyGame"
     database_path = "hockey.db"
+    data_dir = "/tmp"
     match_quality_threshold = 0.8
     percentage_min_players_waiting = 0.1
     percental_time_bonus = 0.1

--- a/comprl/examples/rockpaperscissors/config.toml
+++ b/comprl/examples/rockpaperscissors/config.toml
@@ -5,6 +5,7 @@
     game_path = "examples/rockpaperscissors/game.py"
     game_class = "RPSGame"
     database_path = "RPS.db"
+    data_dir = "/tmp"
     match_quality_threshold = 0.8
     percentage_min_players_waiting = 0.1
     percental_time_bonus = 0.1

--- a/comprl/examples/simple/config.toml
+++ b/comprl/examples/simple/config.toml
@@ -5,6 +5,7 @@
     game_path = "examples/simple/game.py"
     game_class = "ExampleGame"
     database_path = "simple.db"
+    data_dir = "/tmp"
     match_quality_threshold = 0.8
     percentage_min_players_waiting = 0.1
     percental_time_bonus = 0.1


### PR DESCRIPTION
Add a config value "data_dir" which is expected to point to an existing directory.  This is used as base for the "game_actions" directory to which the game data is saved.