### PR TITLE
Enable bot users and Refactor matchmaking queue

### DIFF
--- a/comprl/comprl/scripts/update_user.py
+++ b/comprl/comprl/scripts/update_user.py
@@ -11,6 +11,7 @@ import sys
 import sqlalchemy as sa
 
 from comprl.server.data.sql_backend import User, hash_password
+from comprl.server.data.interfaces import UserRole
 
 
 def main() -> int:
@@ -19,6 +20,12 @@ def main() -> int:
     parser.add_argument("database", type=str, help="Path to the database file.")
     parser.add_argument("username", type=str, help="Name of the user")
     parser.add_argument("--set-password", action="store_true", help="Set new password")
+    parser.add_argument(
+        "--set-role",
+        type=str,
+        choices=[UserRole.USER.value, UserRole.ADMIN.value, UserRole.BOT.value],
+        help="Set new role",
+    )
     parser.add_argument(
         "--verbose", "-v", action="store_true", help="Enable verbose output."
     )
@@ -46,6 +53,10 @@ def main() -> int:
                 print("FAILURE: Passwords do not match.")
                 return 1
             user.password = hash_password(new_pw)
+            changed = True
+
+        if args.set_role:
+            user.role = args.set_role
             changed = True
 
         if changed:

--- a/comprl/comprl/server/__main__.py
+++ b/comprl/comprl/server/__main__.py
@@ -141,7 +141,9 @@ def main():
         return
 
     server = Server(game_type)
-    networking.launch_server(server, conf.port)
+    networking.launch_server(
+        server=server, port=conf.port, update_interval=conf.server_update_interval
+    )
 
 
 if __name__ == "__main__":

--- a/comprl/comprl/server/config.py
+++ b/comprl/comprl/server/config.py
@@ -19,6 +19,8 @@ class Config:
 
     #: Port to listen on
     port: int = 8080
+    #: Update interval for the matchmaking
+    server_update_interval: float = 1.0
     #: Seconds to wait for a player to answer
     timeout: int = 10
     #: Log level used by the server

--- a/comprl/comprl/server/data/interfaces.py
+++ b/comprl/comprl/server/data/interfaces.py
@@ -83,8 +83,10 @@ class UserRole(Enum):
 
     Attributes:
         USER: Normal user without administrative rights.
-        ADMIN = User with administrative rights.
+        ADMIN: User with administrative rights.
+        BOT: Bot-user.  Bots are treated differently during matchmaking.
     """
 
     USER = "user"
     ADMIN = "admin"
+    BOT = "bot"

--- a/comprl/comprl/server/data/sql_backend.py
+++ b/comprl/comprl/server/data/sql_backend.py
@@ -13,6 +13,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from comprl.server.data.interfaces import GameResult, UserRole
+from comprl.server.config import get_config
 
 
 DEFAULT_MU = 25.0
@@ -113,13 +114,16 @@ class GameData:
 class UserData:
     """Represents a data access object for managing game data in a SQLite database."""
 
-    def __init__(self, db_path: str | os.PathLike) -> None:
+    def __init__(self, db_path: str | os.PathLike | None = None) -> None:
         """
         Initializes a new instance of the UserData class.
 
         Args:
             db_path: Path to the sqlite database.
         """
+        if db_path is None:
+            db_path = get_config().database_path
+
         # connect to the database
         db_url = f"sqlite:///{db_path}"
         self.engine = sa.create_engine(db_url)

--- a/comprl/comprl/server/data/sql_backend.py
+++ b/comprl/comprl/server/data/sql_backend.py
@@ -167,19 +167,28 @@ class UserData:
 
             return user.user_id
 
-    def get_user_id(self, user_token: str) -> int | None:
-        """
-        Retrieves the ID of a user based on their token.
+    def get(self, user_id: int) -> User:
+        """Get user with the specified ID."""
+        with sa.orm.Session(self.engine) as session:
+            user = session.get(User, user_id)
+
+        if user is None:
+            raise ValueError(f"User with ID {user_id} not found.")
+
+        return user
+
+    def get_user_by_token(self, access_token: str) -> User | None:
+        """Retrieves a user based on their access token.
 
         Args:
-            user_token (str): The token of the user.
+            access_token: The access token of the user.
 
         Returns:
-            int: The ID of the user, or None if the user is not found.
+            User instance or None if no user with the given token is found.
         """
         with sa.orm.Session(self.engine) as session:
-            user = session.query(User).filter(User.token == user_token).first()
-            return user.user_id if user is not None else None
+            user = session.query(User).filter(User.token == access_token).first()
+            return user
 
     def get_matchmaking_parameters(self, user_id: int) -> tuple[float, float]:
         """

--- a/comprl/comprl/server/managers.py
+++ b/comprl/comprl/server/managers.py
@@ -294,7 +294,7 @@ class MatchmakingManager:
 
         config = get_config()
 
-        # queue storing player id, mu, sigma and time they joined the queue
+        # queue storing player info and time they joined the queue
         self._queue: list[QueueEntry] = []
         # The model used for matchmaking
         self.model = PlackettLuce()
@@ -334,7 +334,6 @@ class MatchmakingManager:
         if user_id is None:
             log.error(f"Player {player_id} is not authenticated but tried to queue.")
             return
-        # mu, sigma = self.player_manager.get_matchmaking_parameters(user_id)
         user = self.player_manager.get_user(user_id)
         if user is None:
             log.error(
@@ -425,6 +424,13 @@ class MatchmakingManager:
         """
         # prevent the user from playing against himself
         if player1.user.user_id == player2.user.user_id:
+            return False
+
+        # do not match if both players are bots
+        if (
+            UserRole(player1.user.role) == UserRole.BOT
+            and UserRole(player2.user.role) == UserRole.BOT
+        ):
             return False
 
         match_quality = self._rate_match_quality(player1, player2)

--- a/comprl/comprl/server/managers.py
+++ b/comprl/comprl/server/managers.py
@@ -366,16 +366,29 @@ class MatchmakingManager:
         Args:
             player_id (PlayerID): The ID of the player to be removed.
         """
-
-    def _update(self, start_index: int = 0) -> None:
         self._queue = [entry for entry in self._queue if (entry.player_id != player_id)]
+
+    def _update(self) -> None:
+        self._match_quality_scores: list[tuple[str, str, float]] = []
+
+        # TODO: don't print to stdout but to shared memory file?
+        # print("Players in queue:")
+        # for entry in self._queue:
+        #     print(entry)
+
+        self._search_for_matches()
+
+        # print("Match quality scores:")
+        # for u1, u2, score in self._match_quality_scores:
+        #     print(f"{u1} vs {u2}: {score}")
+
+    def _search_for_matches(self, start_index: int = 0) -> None:
         """
         Updates the matchmaking manager.
 
         start_index (int, optional): The position in queue to start matching from.
         Used for recursion. Defaults to 0.
         """
-
         if len(self._queue) < self._min_players_waiting():
             return
 
@@ -383,8 +396,8 @@ class MatchmakingManager:
             for j in range(i + 1, len(self._queue)):
                 # try to match all players against each other
                 if self._try_start_game(self._queue[i], self._queue[j]):
-                    # players are matched and removed from queue. continue searching
-                    self._update(i)
+                    # Players are matched and removed from queue. Continue searching.
+                    self._search_for_matches(i)
                     return
         return
 

--- a/comprl/comprl/server/networking.py
+++ b/comprl/comprl/server/networking.py
@@ -31,7 +31,7 @@ class COMPServerProtocol(amp.AMP):
             to be executed when the connection is lost.
     """
 
-    def __init__(self, boxReceiver=None, locator=None):
+    def __init__(self, boxReceiver=None, locator=None) -> None:
         super().__init__(boxReceiver, locator)
 
         self.connection_made_callbacks: list[Callable[[], None]] = []

--- a/comprl/comprl/server/networking.py
+++ b/comprl/comprl/server/networking.py
@@ -434,12 +434,16 @@ class COMPFactory(ServerFactory):
         return protocol
 
 
-def launch_server(server: IServer, port: int = 65335) -> None:
+def launch_server(
+    server: IServer, port: int = 65335, update_interval: float = 1.0
+) -> None:
     """Create a COMP server.
 
     Args:
-        server (IServer): The server instance to be used.
-        port (int): The port number of the server. Defaults to 65335.
+        server: The server instance to be used.
+        port: The port number of the server. Defaults to 65335.
+        update_interval: The interval in seconds for updating the server (matchmaking
+            etc.).
 
     """
     log.info(f"Launching server on port {port}")
@@ -447,5 +451,5 @@ def launch_server(server: IServer, port: int = 65335) -> None:
     reactor.listenTCP(port, COMPFactory(server))  # type: ignore[attr-defined]
 
     # setup and link the on_update event
-    LoopingCall(server.on_update).start(1.0)
+    LoopingCall(server.on_update).start(update_interval)
     reactor.run()  # type: ignore[attr-defined]

--- a/comprl/tests/user_database_test.py
+++ b/comprl/tests/user_database_test.py
@@ -18,7 +18,10 @@ def test_user_data(tmp_path):
     ]
 
     for user_id, user in zip(user_ids, users, strict=True):
-        assert user_data.get_user_id(user[1]) == user_id
+        _user = user_data.get_user_by_token(user[1])
+        assert _user is not None
+        assert _user.user_id == user_id
+        assert _user.username == user[0]
 
     user_data.set_matchmaking_parameters(user_id=user_ids[1], mu=23.0, sigma=3.0)
     mu0, sigma0 = user_data.get_matchmaking_parameters(user_ids[0])


### PR DESCRIPTION
The main contribution of this PR is to enable bot users.  This is done by a very simplistic approach:  Users can be marked as bots (by adding "bot" as a possible user role).  Bot users behave like regular users in the match making, with the only exception that two bot players cannot be matched with each other.

So for using bots, one needs to register one or more users, set their role to "bot" and then run agents for them like a normal user would do (i.e. bot clients are running separately, not as part of the server process).

Another big change of this PR is refactoring the match making queue by using named tuples instead of regular ones (for better readability of the code) and adding the full user information, including the role, which is needed to identify bots.  This also allows to add the username in log messages, which makes debugging easier.

Closes #93