### PR TITLE
Add buttons to download game data in games table

### DIFF
--- a/comprl-hockey-game/config.toml
+++ b/comprl-hockey-game/config.toml
@@ -9,3 +9,4 @@
     match_quality_threshold = 0.8
     percentage_min_players_waiting = 0.1
     percental_time_bonus = 0.1
+    registration_key = "secret"

--- a/comprl-web-reflex/README.md
+++ b/comprl-web-reflex/README.md
@@ -33,12 +33,11 @@ python3 ./create_database_tables.py path/to/comprl/database.db
 
 ## Run
 
-Some configuration values have to be specified via environment variables:
+The path to the comprl config file needs to be specified via an environment
+variable:
 ```
 # Path to the database
-export COMPRL_DB_PATH="/path/to/comprl/database.db"
-# Key that has to be specified to be able to register
-export COMPRL_REGISTRATION_KEY="12345"
+export COMPRL_CONFIG_PATH="/path/to/comprl/config.toml"
 
 reflex run
 ```
@@ -62,10 +61,10 @@ sudo apptainer run -ec --overlay /tmp/overlay \
 ```
 
 In the example above, `/path/to/your/comprl-database` is expected to be a
-directory on the host system, that contains the comprl database.  It is
-expected to be called "comprl.db".  You can set a different name by adding the
+directory on the host system, that contains the comprl config file.  It is
+expected to be called "config.toml".  You can set a different name by adding the
 following argument: ```
---env COMPRL_DB_PATH=/comprl-config/my_database.db
+--env COMPRL_CONFIG_PATH=/comprl-config/my_config.toml
 ```
 
 Note from the [Reflex container example, which was used as a base for

--- a/comprl-web-reflex/comprl-web-reflex.def
+++ b/comprl-web-reflex/comprl-web-reflex.def
@@ -50,8 +50,8 @@ from: python:3.12
     export REDIS_URL=redis://localhost
     export COMPRL_CONFIG_PATH="/comprl-config/config.toml"
 
-%runscript
+%startscript
     . /venv/bin/activate
-    cd /comprl/comprl-web-reflex
     redis-server --daemonize yes
+    cd /comprl/comprl-web-reflex
     reflex run --env prod "$@"

--- a/comprl-web-reflex/comprl-web-reflex.def
+++ b/comprl-web-reflex/comprl-web-reflex.def
@@ -27,12 +27,14 @@ from: python:3.12
     # set up reflex
     cd /comprl/comprl-web-reflex
 
-    # database path and registration key must be set (and db file must exist),
-    # otherwise `reflex export` will fail.  However, the database doesn't need
-    # to be populated and the key can be overwritten at runtime
-    export COMPRL_DB_PATH="/comprl-config/comprl.db"
-    touch $COMPRL_DB_PATH
-    export COMPRL_REGISTRATION_KEY="BUILDTIME"
+    # A valid configuration must be provided, otherwise `reflex export` will
+    # fail...  However, the database doesn't need to be populated and everything
+    # can be overwritten at runtime
+    export COMPRL_CONFIG_PATH="/comprl-config/config.toml"
+    echo '[CompetitionServer]' > $COMPRL_CONFIG_PATH
+    echo 'registration_key = "BUILDTIME"' >> $COMPRL_CONFIG_PATH
+    echo 'database_path = "/tmp/foobar.db"' >> $COMPRL_CONFIG_PATH
+    touch /tmp/foobar.db
 
     # Deploy templates and prepare app
     reflex init
@@ -46,8 +48,7 @@ from: python:3.12
 
 %environment
     export REDIS_URL=redis://localhost
-    export COMPRL_DB_PATH="/comprl-config/comprl.db"
-    export COMPRL_REGISTRATION_KEY="rl-lecture"
+    export COMPRL_CONFIG_PATH="/comprl-config/config.toml"
 
 %runscript
     . /venv/bin/activate

--- a/comprl-web-reflex/comprl_web/config.py
+++ b/comprl-web-reflex/comprl_web/config.py
@@ -1,0 +1,3 @@
+from comprl.server.config import load_config, get_config
+
+__all__ = ["load_config", "get_config"]

--- a/comprl-web-reflex/comprl_web/pages/games.py
+++ b/comprl-web-reflex/comprl_web/pages/games.py
@@ -6,8 +6,34 @@ List of all games of the logged in user.
 import reflex as rx
 
 from ..components import standard_layout
-from ..protected_state import ProtectedState
+from ..protected_state import ProtectedState, GameInfo
 from .. import reflex_local_auth
+
+
+def show_game(game: GameInfo) -> rx.Component:
+    """Show a game in a table row."""
+    return rx.table.row(
+        rx.table.cell(game.player1),
+        rx.table.cell(game.player2),
+        rx.table.cell(game.result),
+        rx.table.cell(game.time),
+        rx.table.cell(game.id),
+    )
+
+
+def user_game_table() -> rx.Component:
+    return rx.table.root(
+        rx.table.header(
+            rx.table.row(
+                rx.foreach(
+                    ProtectedState.user_games_header, rx.table.column_header_cell
+                )
+            ),
+        ),
+        rx.table.body(rx.foreach(ProtectedState.user_games, show_game)),
+        on_mount=ProtectedState.load_user_games,
+        width="100%",
+    )
 
 
 @rx.page(on_load=ProtectedState.on_load)
@@ -16,12 +42,7 @@ def game_overview() -> rx.Component:
     return standard_layout(
         rx.cond(
             ProtectedState.user_games,
-            rx.data_table(
-                data=ProtectedState.user_games,
-                columns=ProtectedState.user_games_header,
-                search=True,
-                pagination=True,
-            ),
+            user_game_table(),
             rx.text("No games played yet."),
         ),
         heading="Games",

--- a/comprl-web-reflex/comprl_web/pages/games.py
+++ b/comprl-web-reflex/comprl_web/pages/games.py
@@ -23,6 +23,13 @@ def show_game(game: GameInfo) -> rx.Component:
 
 def user_game_table() -> rx.Component:
     return rx.vstack(
+        rx.cond(
+            UserGamesState.search_id,
+            rx.hstack(
+                rx.text(f"Search results for game ID: {UserGamesState.search_id}"),
+                rx.button("Clear search", on_click=UserGamesState.clear_search),
+            ),
+        ),
         rx.table.root(
             rx.table.header(
                 rx.table.row(
@@ -37,6 +44,10 @@ def user_game_table() -> rx.Component:
         ),
         rx.hstack(
             rx.button(
+                "First",
+                on_click=UserGamesState.first_page,
+            ),
+            rx.button(
                 "Prev",
                 on_click=UserGamesState.prev_page,
             ),
@@ -48,7 +59,18 @@ def user_game_table() -> rx.Component:
                 on_click=UserGamesState.next_page,
             ),
         ),
-        rx.text(f"Games played: {UserGamesState.total_items}"),
+        rx.form(
+            rx.hstack(
+                rx.text("Search for game ID:"),
+                rx.input(
+                    name="search_id",
+                    placeholder="Game ID",
+                ),
+                rx.button("Search"),
+            ),
+            on_submit=UserGamesState.search_game,
+        ),
+        # rx.text(f"Games played: {UserGamesState.total_items}"),
     )
 
 

--- a/comprl-web-reflex/comprl_web/pages/games.py
+++ b/comprl-web-reflex/comprl_web/pages/games.py
@@ -18,11 +18,29 @@ def show_game(game: GameInfo) -> rx.Component:
         rx.table.cell(game.result),
         rx.table.cell(game.time),
         rx.table.cell(game.id),
+        rx.table.cell(
+            rx.button(
+                "Download game data",
+                on_click=lambda: UserGamesState.download_game(game.id),
+            )
+        ),
     )
 
 
 def user_game_table() -> rx.Component:
     return rx.vstack(
+        rx.form(
+            rx.hstack(
+                rx.text("Search for game ID:"),
+                rx.input(
+                    name="search_id",
+                    placeholder="Game ID",
+                    width="38ex",
+                ),
+                rx.button("Search"),
+            ),
+            on_submit=UserGamesState.search_game,
+        ),
         rx.cond(
             UserGamesState.search_id,
             rx.hstack(
@@ -59,18 +77,6 @@ def user_game_table() -> rx.Component:
                 on_click=UserGamesState.next_page,
             ),
         ),
-        rx.form(
-            rx.hstack(
-                rx.text("Search for game ID:"),
-                rx.input(
-                    name="search_id",
-                    placeholder="Game ID",
-                ),
-                rx.button("Search"),
-            ),
-            on_submit=UserGamesState.search_game,
-        ),
-        # rx.text(f"Games played: {UserGamesState.total_items}"),
     )
 
 
@@ -78,10 +84,6 @@ def user_game_table() -> rx.Component:
 @reflex_local_auth.require_login
 def game_overview() -> rx.Component:
     return standard_layout(
-        rx.cond(
-            UserGamesState.user_games,
-            user_game_table(),
-            rx.text("No games played yet."),
-        ),
+        user_game_table(),
         heading="Games",
     )

--- a/comprl-web-reflex/comprl_web/pages/games.py
+++ b/comprl-web-reflex/comprl_web/pages/games.py
@@ -6,7 +6,7 @@ List of all games of the logged in user.
 import reflex as rx
 
 from ..components import standard_layout
-from ..protected_state import ProtectedState, GameInfo
+from ..protected_state import UserGamesState, GameInfo
 from .. import reflex_local_auth
 
 
@@ -22,26 +22,42 @@ def show_game(game: GameInfo) -> rx.Component:
 
 
 def user_game_table() -> rx.Component:
-    return rx.table.root(
-        rx.table.header(
-            rx.table.row(
-                rx.foreach(
-                    ProtectedState.user_games_header, rx.table.column_header_cell
-                )
+    return rx.vstack(
+        rx.table.root(
+            rx.table.header(
+                rx.table.row(
+                    rx.foreach(
+                        UserGamesState.user_games_header, rx.table.column_header_cell
+                    )
+                ),
+            ),
+            rx.table.body(rx.foreach(UserGamesState.user_games, show_game)),
+            on_mount=UserGamesState.load_user_games,
+            width="100%",
+        ),
+        rx.hstack(
+            rx.button(
+                "Prev",
+                on_click=UserGamesState.prev_page,
+            ),
+            rx.text(
+                f"Page {UserGamesState.page_number} / {UserGamesState.total_pages}"
+            ),
+            rx.button(
+                "Next",
+                on_click=UserGamesState.next_page,
             ),
         ),
-        rx.table.body(rx.foreach(ProtectedState.user_games, show_game)),
-        on_mount=ProtectedState.load_user_games,
-        width="100%",
+        rx.text(f"Games played: {UserGamesState.total_items}"),
     )
 
 
-@rx.page(on_load=ProtectedState.on_load)
+@rx.page(on_load=UserGamesState.on_load)
 @reflex_local_auth.require_login
 def game_overview() -> rx.Component:
     return standard_layout(
         rx.cond(
-            ProtectedState.user_games,
+            UserGamesState.user_games,
             user_game_table(),
             rx.text("No games played yet."),
         ),

--- a/comprl-web-reflex/comprl_web/pages/games.py
+++ b/comprl-web-reflex/comprl_web/pages/games.py
@@ -28,6 +28,7 @@ def show_game(game: GameInfo) -> rx.Component:
 
 
 def user_game_table() -> rx.Component:
+    """Render the user game table."""
     return rx.vstack(
         rx.form(
             rx.hstack(

--- a/comprl-web-reflex/comprl_web/pages/leaderboard.py
+++ b/comprl-web-reflex/comprl_web/pages/leaderboard.py
@@ -3,16 +3,16 @@
 import reflex as rx
 
 from ..components import standard_layout
-from ..protected_state import ProtectedState
+from ..protected_state import UserDashboardState
 from .. import reflex_local_auth
 
 
-@rx.page(on_load=ProtectedState.on_load)
+@rx.page(on_load=UserDashboardState.on_load)
 @reflex_local_auth.require_login
 def leaderboard() -> rx.Component:
     return standard_layout(
         rx.data_table(
-            data=ProtectedState.ranked_users,
+            data=UserDashboardState.ranked_users,
             columns=["Ranking", "Username", "µ / Σ"],
             search=True,
             sort=False,

--- a/comprl-web-reflex/comprl_web/pages/user_dashboard.py
+++ b/comprl-web-reflex/comprl_web/pages/user_dashboard.py
@@ -3,17 +3,17 @@
 import reflex as rx
 
 from ..components import standard_layout
-from ..protected_state import ProtectedState
+from ..protected_state import UserDashboardState
 from .. import reflex_local_auth
 from ..reflex_local_auth.local_auth import LocalAuthState
 
 
-@rx.page(on_load=ProtectedState.on_load)
+@rx.page(on_load=UserDashboardState.on_load)
 @reflex_local_auth.require_login
 def dashboard() -> rx.Component:
     win_rate = round(
-        ProtectedState.game_statistics.num_games_won
-        / ProtectedState.game_statistics.num_games_played
+        UserDashboardState.game_statistics.num_games_won
+        / UserDashboardState.game_statistics.num_games_played
         * 100
     )
 
@@ -30,15 +30,19 @@ def dashboard() -> rx.Component:
                 ),
                 rx.data_list.item(
                     rx.data_list.label("Ranking"),
-                    rx.data_list.value(f"{ProtectedState.ranking_position}. place"),
+                    rx.data_list.value(f"{UserDashboardState.ranking_position}. place"),
                 ),
                 rx.data_list.item(
                     rx.data_list.label("Games Played"),
-                    rx.data_list.value(ProtectedState.game_statistics.num_games_played),
+                    rx.data_list.value(
+                        UserDashboardState.game_statistics.num_games_played
+                    ),
                 ),
                 rx.data_list.item(
                     rx.data_list.label("Games Won"),
-                    rx.data_list.value(ProtectedState.game_statistics.num_games_won),
+                    rx.data_list.value(
+                        UserDashboardState.game_statistics.num_games_won
+                    ),
                 ),
                 rx.data_list.item(
                     rx.data_list.label("Win rate"),
@@ -46,7 +50,9 @@ def dashboard() -> rx.Component:
                 ),
                 rx.data_list.item(
                     rx.data_list.label("Disconnects"),
-                    rx.data_list.value(ProtectedState.game_statistics.num_disconnects),
+                    rx.data_list.value(
+                        UserDashboardState.game_statistics.num_disconnects
+                    ),
                 ),
             ),
         ),

--- a/comprl-web-reflex/comprl_web/protected_state.py
+++ b/comprl-web-reflex/comprl_web/protected_state.py
@@ -75,14 +75,14 @@ class ProtectedState(reflex_local_auth.LocalAuthState):
 
         return ranked_users
 
-    @rx.var
+    @rx.var(cache=False)
     def ranked_users(self) -> Sequence[tuple[int, str, str]]:
         return [
             (i + 1, user.username, f"{user.mu:.2f} / {user.sigma:.2f}")
             for i, user in enumerate(self._get_ranked_users())
         ]
 
-    @rx.var
+    @rx.var(cache=False)
     def ranking_position(self) -> int:
         if not self.is_authenticated:
             return -1
@@ -117,7 +117,7 @@ class ProtectedState(reflex_local_auth.LocalAuthState):
 
     user_games_header: list[str] = ["Player 1", "Player 2", "Result", "Time", "ID"]
 
-    @rx.var
+    @rx.var(cache=False)
     def user_games(self) -> Sequence[Sequence[str]]:
         games = []
         for game in self._get_user_games():

--- a/comprl-web-reflex/comprl_web/protected_state.py
+++ b/comprl-web-reflex/comprl_web/protected_state.py
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 from comprl.server.data.sql_backend import Game, User
 from comprl.server.data.interfaces import GameEndState
 
-from . import reflex_local_auth
+from . import config, reflex_local_auth
 from .reflex_local_auth.local_auth import get_session
 
 
@@ -103,7 +103,7 @@ class UserDashboardState(ProtectedState):
 
 
 class UserGamesState(ProtectedState):
-    user_games_header: list[str] = ["Player 1", "Player 2", "Result", "Time", "ID"]
+    user_games_header: list[str] = ["Player 1", "Player 2", "Result", "Time", "ID", ""]
     user_games: list[GameInfo] = []
     search_id: str = ""
 
@@ -220,3 +220,15 @@ class UserGamesState(ProtectedState):
             )
 
         self.total_items = self._get_num_user_games()
+
+    @rx.event
+    def download_game(self, game_id: str):
+        game_file_name = f"{game_id}.pkl"
+        game_file_path = config.get_config().data_dir / "game_actions" / game_file_name
+
+        try:
+            data = game_file_path.read_bytes()
+        except Exception:
+            raise RuntimeError("Game file not found") from None
+
+        return rx.download(filename=game_file_name, data=data)

--- a/comprl-web-reflex/comprl_web/protected_state.py
+++ b/comprl-web-reflex/comprl_web/protected_state.py
@@ -30,6 +30,8 @@ class GameInfo:
 
 
 class ProtectedState(reflex_local_auth.LocalAuthState):
+    """Base for protected states."""
+
     def on_load(self):
         if not self.is_authenticated:
             return reflex_local_auth.LoginState.redir
@@ -103,6 +105,8 @@ class UserDashboardState(ProtectedState):
 
 
 class UserGamesState(ProtectedState):
+    """State for the user games page."""
+
     user_games_header: list[str] = ["Player 1", "Player 2", "Result", "Time", "ID", ""]
     user_games: list[GameInfo] = []
     search_id: str = ""

--- a/comprl-web-reflex/comprl_web/reflex_local_auth/local_auth.py
+++ b/comprl-web-reflex/comprl_web/reflex_local_auth/local_auth.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 
 import datetime
 
-from sqlmodel import select
-
 import sqlalchemy as sa
 import reflex as rx
 
@@ -38,7 +36,7 @@ class LocalAuthState(rx.State):
 
     @rx.var(cache=True)
     def authenticated_user(self) -> User | None:
-        """The currently authenticated user, or a dummy user if not authenticated.
+        """The currently authenticated user.
 
         Returns:
             User instance corresponding to the currently authenticated user or None if
@@ -46,7 +44,7 @@ class LocalAuthState(rx.State):
         """
         with get_session() as session:
             result = session.scalars(
-                select(User, LocalAuthSession).where(
+                sa.select(User, LocalAuthSession).where(
                     LocalAuthSession.session_id == self.auth_token,
                     LocalAuthSession.expiration
                     >= datetime.datetime.now(datetime.timezone.utc),
@@ -70,7 +68,7 @@ class LocalAuthState(rx.State):
         """Destroy LocalAuthSessions associated with the auth_token."""
         with get_session() as session:
             for auth_session in session.scalars(
-                select(LocalAuthSession).where(
+                sa.select(LocalAuthSession).where(
                     LocalAuthSession.session_id == self.auth_token
                 )
             ).all():

--- a/comprl-web-reflex/comprl_web/reflex_local_auth/local_auth.py
+++ b/comprl-web-reflex/comprl_web/reflex_local_auth/local_auth.py
@@ -16,6 +16,7 @@ import reflex as rx
 
 from comprl.server.data.sql_backend import User
 
+from .. import config
 from .auth_session import LocalAuthSession
 
 AUTH_TOKEN_LOCAL_STORAGE_KEY = "_auth_token"
@@ -25,7 +26,7 @@ DEFAULT_AUTH_REFRESH_DELTA = datetime.timedelta(minutes=10)
 
 # TODO move to other module?
 def get_session() -> sa.orm.Session:
-    db_url = f"sqlite:///{rx.config.get_config().comprl_db_path}"
+    db_url = f"sqlite:///{config.get_config().database_path}"
     engine = sa.create_engine(db_url)
     return sa.orm.Session(engine)
 

--- a/comprl-web-reflex/comprl_web/reflex_local_auth/login.py
+++ b/comprl-web-reflex/comprl_web/reflex_local_auth/login.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import bcrypt
 import reflex as rx
-from sqlmodel import select
+from sqlalchemy import select
 
 from comprl.server.data.sql_backend import User
 
@@ -44,10 +44,6 @@ class LoginState(LocalAuthState):
         self.error_message = ""
         username = form_data["username"]
         password = form_data["password"]
-        # with rx.session() as session:
-        #    user = session.exec(
-        #        select(User).where(User.username == username)
-        #    ).one_or_none()
 
         with get_session() as session:
             user = session.scalars(

--- a/comprl-web-reflex/comprl_web/reflex_local_auth/registration.py
+++ b/comprl-web-reflex/comprl_web/reflex_local_auth/registration.py
@@ -7,7 +7,7 @@ import re
 
 import reflex as rx
 
-from sqlmodel import select
+from sqlalchemy import select
 
 from comprl.server.util import IDGenerator
 from comprl.server.data.sql_backend import User, hash_password

--- a/comprl-web-reflex/comprl_web/reflex_local_auth/registration.py
+++ b/comprl-web-reflex/comprl_web/reflex_local_auth/registration.py
@@ -9,11 +9,13 @@ import reflex as rx
 
 from sqlmodel import select
 
+from comprl.server.util import IDGenerator
+from comprl.server.data.sql_backend import User, hash_password
+
+from ..config import get_config
 from . import routes
 from .local_auth import LocalAuthState, get_session
 
-from comprl.server.util import IDGenerator
-from comprl.server.data.sql_backend import User, hash_password
 
 POST_REGISTRATION_DELAY = 0.5
 PASSWORD_MIN_LENGTH = 8
@@ -34,7 +36,7 @@ class RegistrationState(LocalAuthState):
     def _validate_fields(
         self, registration_key: str, username: str, password: str, confirm_password: str
     ) -> rx.event.EventSpec | list[rx.event.EventSpec] | None:
-        if registration_key != rx.config.get_config().comprl_registration_key:
+        if registration_key != get_config().registration_key:
             self.error_message = "Invalid registration key"
             return rx.set_focus("key")
 

--- a/comprl-web-reflex/rxconfig.py
+++ b/comprl-web-reflex/rxconfig.py
@@ -2,10 +2,8 @@ import reflex as rx
 
 
 class CustomConfig(rx.Config):
-    # path tot he comprl database
-    comprl_db_path: str = ""
-    # key that has to be specified to register
-    comprl_registration_key: str = ""
+    # path to comprl config file
+    comprl_config_path: str = ""
 
 
 config = CustomConfig(

--- a/comprl/CHANGELOG.md
+++ b/comprl/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ```
 - BREAKING: `Agent` is now an abstract class and cannot be instantiated anymore.
   Instead, derive a custom class from it, that implements the `get_step` method.
+- BREAKING: Relative paths in the config file are now resolved relative to the
+  config file location instead of to the working directory.
 
 ## Removed
 - The `Agent.event` decorator has been removed.  Instead of using it, create

--- a/comprl/examples/rockpaperscissors/config.toml
+++ b/comprl/examples/rockpaperscissors/config.toml
@@ -2,7 +2,7 @@
     port = 65335
     timeout = 10
     log_level = "DEBUG"
-    game_path = "examples/rockpaperscissors/game.py"
+    game_path = "game.py"
     game_class = "RPSGame"
     database_path = "RPS.db"
     data_dir = "/tmp"

--- a/comprl/examples/simple/config.toml
+++ b/comprl/examples/simple/config.toml
@@ -2,7 +2,7 @@
     port = 65335
     timeout = 10
     log_level = "DEBUG"
-    game_path = "examples/simple/game.py"
+    game_path = "game.py"
     game_class = "ExampleGame"
     database_path = "simple.db"
     data_dir = "/tmp"

--- a/comprl/src/comprl/server/config.py
+++ b/comprl/src/comprl/server/config.py
@@ -41,6 +41,9 @@ class Config:
     #: (Minutes waiting * percentage) added as a time bonus for waiting players
     percental_time_bonus: float = 0.1
 
+    # key that has to be specified to register
+    registration_key: str = ""
+
 
 _config: Config | None = None
 


### PR DESCRIPTION
Each row of the games table now has a download button to download the pickle file with the data of the corresponding game. 

To make this work, a couple of changes were necessary:
- Relative paths in the comprl config file are now resolved relative to the config file location and not, as previously, to the working directory.  This is needed as comprl-web-reflex uses that file as well now and will typically run from a different directory.  Anyway, I think this is the more expected behaviour.
- comprl-web-reflex loads the config file now, instead of getting each setting separately.  This is needed to get the `data_dir`, which contains the game files.
- Use `rx.table` instead of `rx.data_table` for the games.  The latter doesn't seem to allow adding buttons or the like.  Unfortunately, this means that search and pagination had to be implemented manually now.  Pagination should work more or less as before.  Search is limited in so far that it only can search for exact matches of game ids.

This PR also makes some change to the reflex container, so it can more properly be run as a service instance.